### PR TITLE
Updated the package name according to the npm registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Now in the below steps, I will assume you are already done with the provider.
 ## Integration Steps
 1. First Install the Github cards plugin by running this command from the root of the package.
 ```shell
-yarn add –cwd packages/app @statusneo/backstage-github-plugin
+yarn add –cwd packages/app @statusneo/backstage-plugin-github
 ```
 
 2. Import GithubPullRequestsCard, and GithubActionsCard from the installed package


### PR DESCRIPTION
Updated the package name according to the [npm registry](https://www.npmjs.com/package/@statusneo/backstage-plugin-github?activeTab=readme) `npm i @statusneo/backstage-plugin-github`, the present name is wrong and throws this error when trying to add it to the backstage instance 
```
yarn add v1.22.19
[1/4] 🔍  Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/@statusneo%2fbackstage-github-plugin: Not found".
```